### PR TITLE
Add support for listing recordsets across all zones

### DIFF
--- a/openstack/dns/v2/recordsets/requests.go
+++ b/openstack/dns/v2/recordsets/requests.go
@@ -42,9 +42,30 @@ func (opts ListOpts) ToRecordSetListQuery() (string, error) {
 	return q.String(), err
 }
 
-// ListByZone implements the recordset list request.
+// ListByZone implements the recordset list request for a specific zone.
 func ListByZone(client *gophercloud.ServiceClient, zoneID string, opts ListOptsBuilder) pagination.Pager {
 	url := baseURL(client, zoneID)
+	if opts != nil {
+		query, err := opts.ToRecordSetListQuery()
+		if err != nil {
+			return pagination.Pager{Err: err}
+		}
+		url += query
+	}
+	return pagination.NewPager(client, url, func(r pagination.PageResult) pagination.Page {
+		return RecordSetPage{pagination.LinkedPageBase{PageResult: r}}
+	})
+}
+
+// listAllRecordSetsURL builds the base URL for listing recordsets across all
+// zones.
+func listAllRecordSetsURL(c *gophercloud.ServiceClient) string {
+	return c.ServiceURL("recordsets")
+}
+
+// ListAll implements the recordset list request across all zones.
+func ListAll(client *gophercloud.ServiceClient, opts ListOptsBuilder) pagination.Pager {
+	url := listAllRecordSetsURL(client)
 	if opts != nil {
 		query, err := opts.ToRecordSetListQuery()
 		if err != nil {
@@ -155,7 +176,7 @@ func (opts UpdateOpts) ToRecordSetUpdateMap() (map[string]any, error) {
 	return b, nil
 }
 
-// Update updates a recordset in a given zone
+// Update updates a recordset in a given zone.
 func Update(ctx context.Context, client *gophercloud.ServiceClient, zoneID string, rrsetID string, opts UpdateOptsBuilder) (r UpdateResult) {
 	b, err := opts.ToRecordSetUpdateMap()
 	if err != nil {


### PR DESCRIPTION
This change introduces a new ListAll function and helper URL builder to expose the Designate /recordsets endpoint via gophercloud. This allows callers to retrieve recordsets across all zones, in addition to the existing per-zone ListByZone helper.

The new ListAll function:
- Reuses the existing ListOpts/ListOptsBuilder types for filtering, sorting, and pagination.
- Returns a pagination.Pager consistent with other list operations in this package.

<!--
Prior to starting a PR, please make sure you have read our
[contributor tutorial](https://github.com/gophercloud/gophercloud/tree/main/docs/contributor-tutorial).

Prior to a PR being reviewed, there needs to be a Github issue that the PR
addresses. Replace the brackets and text below with that issue number.

-->
Fixes #[PUT ISSUE NUMBER HERE]

Links to the line numbers/files in the OpenStack source code that support the
code in this PR:

[PUT URLS HERE]
